### PR TITLE
Issue #10: check for global composer autoload

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -5,7 +5,13 @@
 
 error_reporting(E_ALL);
 
-require_once __DIR__ . '/vendor/autoload.php';
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../vendor/autoload.php')) {
+    require_once __DIR__ . '/../../../vendor/autoload.php';
+} else {
+    throw \Exception("Could not find 'vendor/autoload.php'.");
+}
 
 use Lstr\DnsmasqMgmt\Service\DnsmasqMgmtServiceProvider;
 


### PR DESCRIPTION
If dnsmasq-mgmt is installed using 'composer global require',
autoload.php ends up in a different place