### PR TITLE
Fix missing dnsmasq and resolver directories

### DIFF
--- a/src/Lstr/DnsmasqMgmt/Service/BrewEnvironmentService.php
+++ b/src/Lstr/DnsmasqMgmt/Service/BrewEnvironmentService.php
@@ -32,9 +32,7 @@ class BrewEnvironmentService implements EnvironmentServiceInterface
     {
         $setup_commands = $this->getSetupCommands();
         $sudo_commands = $this->process_service->prependSudo($setup_commands);
-        $all_commands = [
-            'brew install dnsmasq',
-        ] + $sudo_commands;
+        $all_commands = array_merge(['brew install dnsmasq'], $sudo_commands);
 
         $this->process_service->mustRun($all_commands);
 


### PR DESCRIPTION
The missing directories are causing the dnsmasq
configuring to fail.  The directories are missing
because the array union operator was overwriting
the `mkdir` command with the `brew install` rather
than appending the two numerically-indexed arrays.