### PR TITLE
Use `brew services` instead of manipulating launchd

### DIFF
--- a/src/Lstr/DnsmasqMgmt/Service/BrewEnvironmentService.php
+++ b/src/Lstr/DnsmasqMgmt/Service/BrewEnvironmentService.php
@@ -88,9 +88,7 @@ TXT;
             "touch {$this->dnsmasq_config}",
             "chown {$user_name}:admin {$this->dnsmasq_config} "
                 . "{$this->dnsmasq_dir} {$this->resolver_dir}",
-            "cp /usr/local/opt/dnsmasq/homebrew.mxcl.dnsmasq.plist /Library/LaunchDaemons",
-            "launchctl unload /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist",
-            "launchctl load /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist",
+            "brew services start dnsmasq",
         ];
 
         return $this->setup_commands;


### PR DESCRIPTION
Manipulating launchd does not work for the latest version
of dnsmasq via brew because the launchd config no longer
exists.